### PR TITLE
feat: add old-version banner for v4 docs

### DIFF
--- a/.vitepress/components/OldDocument.vue
+++ b/.vitepress/components/OldDocument.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="old-document">
+    <p>
+      本文档适用于 v4 <strong>（旧版本）</strong>。如需查看最新版本请访问
+      <a href="https://cn.vitest.dev" class="new-document-link">https://cn.vitest.dev</a>.
+    </p>
+  </div>
+</template>
+
+<style>
+:root {
+  --vp-old-document-height: 96px;
+}
+
+@media (min-width: 455px) {
+  :root {
+    --vp-old-document-height: 64px;
+  }
+}
+
+@media (min-width: 960px) {
+  :root {
+    --vp-old-document-height: 32px;
+  }
+}
+
+.old-document {
+  display: flex;
+  height: var(--vp-old-document-height);
+  width: 100%;
+  padding: 4px 32px;
+  justify-content: center;
+  align-items: center;
+  color: #2a3a1b;
+  background: #f4f8e0;
+  z-index: var(--vp-z-index-layout-top);
+}
+
+.dark .old-document,
+[data-theme='dark'] .old-document {
+  color: #c5d9b6;
+  background: #2d3b2e;
+}
+
+.old-document p {
+  color: inherit !important;
+  font-size: 1rem !important;
+  line-height: 1.75rem !important;
+}
+
+.old-document .new-document-link {
+  text-decoration: underline;
+  color: var(--vp-c-text-1);
+}
+
+.old-document .new-document-link:hover {
+  color: var(--vp-c-text-2);
+}
+
+@media (min-width: 1024px) {
+  :root:has(.docs-layout) {
+    --vp-banner-height: var(--vp-old-document-height);
+    --vp-layout-top-height: var(--vp-old-document-height);
+  }
+
+  :root:has(.docs-layout) .old-document {
+    position: fixed;
+    top: 0;
+  }
+}
+</style>

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -136,12 +136,6 @@ export default ({ mode }: { mode: string }) => {
         },
       },
 
-      banner: {
-        id: 'viteplus-alpha',
-        text: 'Announcing Vite+ Alpha: Open source. Unified. Next-gen.',
-        url: 'https://voidzero.dev/posts/announcing-vite-plus-alpha?utm_source=vitest&utm_content=top_banner',
-      },
-
       carbonAds: {
         code: 'CW7DVKJE',
         placement: 'vitestdev',

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -3,14 +3,17 @@ import TwoslashFloatingVue from '@shikijs/vitepress-twoslash/client'
 import VitestTheme from '@voidzero-dev/vitepress-theme/src/vitest'
 import { inBrowser } from 'vitepress'
 import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
+import { Fragment, h } from 'vue'
 import Advanced from '../components/Advanced.vue'
 import CourseLink from '../components/CourseLink.vue'
 import CRoot from '../components/CRoot.vue'
 import Deprecated from '../components/Deprecated.vue'
 import Experimental from '../components/Experimental.vue'
+import OldDocument from '../components/OldDocument.vue'
 import Version from '../components/Version.vue'
 import './styles.css'
 import '@shikijs/vitepress-twoslash/style.css'
+
 import 'virtual:group-icons.css'
 
 if (inBrowser) {
@@ -51,6 +54,12 @@ function getRedirectPath(url: URL) {
 
 export default {
   extends: VitestTheme as unknown as any,
+  Layout() {
+    return h(Fragment, null, [
+      h(OldDocument),
+      h(VitestTheme.Layout),
+    ])
+  },
   enhanceApp({ app }) {
     app.component('Version', Version)
     app.component('CRoot', CRoot)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-cn",
   "type": "module",
-  "version": "4.1.4",
+  "version": "4.1.11",
   "private": true,
   "packageManager": "pnpm@9.7.1",
   "scripts": {


### PR DESCRIPTION
- Add an old-version notice banner on v4 docs linking to the latest site
- Remove the Vite+ Alpha top banner
- Bump version to 4.1.11

<!-- 感谢你的贡献！ -->

### 在提交PR之前，请确保你执行以下操作:
- [x] 曾阅读过[翻译须知](https://github.com/vitest-dev/docs-cn/issues/391)。
- [x] 检查是否已经有PR以同样的方式解决问题，以避免创建重复。
- [x] 在此PR中描述正在解决的问题，或引用它解决的问题（例如：`fixes #123`）。

---

### 描述
<!-- 请在此处插入你的描述，并提供有关此PR正在解决的 “内容” 的特别信息 -->

### 附加上下文
<!-- 例如，你有什么想让代码审核的人重点关注的内容。 -->
