### PR TITLE
docs(cn): fix twoslash errors in snapshot guide v1

### DIFF
--- a/guide/snapshot.md
+++ b/guide/snapshot.md
@@ -15,11 +15,11 @@ title: 测试快照 | 指南
 要将一个值快照，你可以使用 `expect()` 的 [`toMatchSnapshot()`](/api/#tomatchsnapshot) API:
 
 ```ts twoslash
-// ---cut---
-import { expect, it } from 'vitest'
 function toUpperCase(str: string) {
   return str
 }
+// ---cut---
+import { expect, it } from 'vitest'
 
 it('toUpperCase', () => {
   const result = toUpperCase('foobar')
@@ -46,6 +46,10 @@ exports['toUpperCase 1'] = '"FOOBAR"'
 如同前文，你可以使用 [`toMatchInlineSnapshot()`](/api/#tomatchinlinesnapshot) 将内联快照存储在测试文件中。
 
 ```ts twoslash
+function toUpperCase(str: string) {
+  return str
+}
+// ---cut---
 import { expect, it } from 'vitest'
 
 it('toUpperCase', () => {
@@ -57,6 +61,10 @@ it('toUpperCase', () => {
 Vitest 不会创建快照文件，而是直接修改测试文件，将快照作为字符串更新到文件中：
 
 ```ts  twoslash
+function toUpperCase(str: string) {
+  return str
+}
+// ---cut---
 import { expect, it } from 'vitest'
 
 it('toUpperCase', () => {


### PR DESCRIPTION
Define the toUpperCase function in inline snapshot examples that reference it without declaring it, fixing the TypeScript 2304 build error.

<!-- 感谢你的贡献！ -->

### 在提交PR之前，请确保你执行以下操作:
- [ ] 曾阅读过[翻译须知](https://github.com/vitest-dev/docs-cn/issues/391)。
- [ ] 检查是否已经有PR以同样的方式解决问题，以避免创建重复。
- [ ] 在此PR中描述正在解决的问题，或引用它解决的问题（例如：`fixes #123`）。

---

### 描述
<!-- 请在此处插入你的描述，并提供有关此PR正在解决的 “内容” 的特别信息 -->

### 附加上下文
<!-- 例如，你有什么想让代码审核的人重点关注的内容。 -->
